### PR TITLE
Workspace rows should now be added when logging in

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -60,7 +60,7 @@ function enable() {
 	for (let k in bindings) {
 		Meta.keybindings_set_custom_handler(bindings[k], Lang.bind(this, onSwitch));
 	}
-
+	updateWorkspaces()
 }
 
 function disable() {


### PR DESCRIPTION
Workspace rows didn't work for me when after logging in - I had to open the extension settings each time to change the rows to one and back to two again to get my second row back.
Calling the updateWorkspaces() function when enabling the extension fixed that.
